### PR TITLE
[WIP][APITEAM-2183]sdkを新バージョンに対応させる

### DIFF
--- a/src/sdk/api/freee-api-client.ts
+++ b/src/sdk/api/freee-api-client.ts
@@ -20,9 +20,13 @@ export class FreeeAPIClient {
     userId: string
   ): AxiosPromise<T> {
     return this.tokenManager.get(userId).then(accessToken => {
+      const headers = {
+        "Authorization": `Bearer ${accessToken}`,
+        "X-API-VERSION": "2020-06-15"
+      }
       return this.axios.get(url, {
         params: params,
-        headers: { Authorization: `Bearer ${accessToken}` }
+        headers: headers
       })
     })
   }
@@ -33,7 +37,7 @@ export class FreeeAPIClient {
   post<T = any>(url: string, data: ParamJSON, userId: string): AxiosPromise<T> {
     return this.tokenManager.get(userId).then(accessToken => {
       return this.axios.post(url, data, {
-        headers: { Authorization: `Bearer ${accessToken}` }
+        headers: headers
       })
     })
   }
@@ -44,7 +48,7 @@ export class FreeeAPIClient {
   put<T = any>(url: string, data: ParamJSON, userId: string): AxiosPromise<T> {
     return this.tokenManager.get(userId).then(accessToken => {
       return this.axios.put(url, data, {
-        headers: { Authorization: `Bearer ${accessToken}` }
+        headers: headers
       })
     })
   }
@@ -56,7 +60,7 @@ export class FreeeAPIClient {
     return this.tokenManager.get(userId).then(accessToken => {
       return this.axios.delete(url, {
         data: data,
-        headers: { Authorization: `Bearer ${accessToken}` }
+        headers: headers
       })
     })
   }

--- a/src/sdk/auth/freee-firebase-auth-client.ts
+++ b/src/sdk/auth/freee-firebase-auth-client.ts
@@ -18,7 +18,7 @@ export class FreeeFirebaseAuthClient {
   private homePath: string
   private appHost: string
   private authHost: string
-  private apiKey?: string
+  // private apiKey?: string
 
   constructor(
     admin: admin.app.App,
@@ -45,7 +45,7 @@ export class FreeeFirebaseAuthClient {
     this.homePath = ConfigManager.get(freeeConfigs, ConfigKeys.homePath)
     this.appHost = ConfigManager.get(freeeConfigs, ConfigKeys.appHost)
     this.authHost = ConfigManager.get(freeeConfigs, ConfigKeys.authHost)
-    this.apiKey = config.firebase && config.firebase.apiKey!
+    // this.apiKey = config.firebase && config.firebase.apiKey!
   }
 
   /**


### PR DESCRIPTION
## 概要

※ビルドに失敗してます

やりたいこと
sdkを新バージョンのAPIを叩く様に変更を加える

やったこと
firebase-sdk-jsに変更を加える (本PR)
firebase-sdk-jsのroot ディレクトリで `npm link`
[freee-app-firebase-template](https://github.com/freee/freee-app-template-firebase) / functions ディレクトリで `npm link freee-firebase-sdk`
/functionsで `npm run build`

ここで失敗する

```
[1]
[1] ERROR in /Users/matsuzawa-shinichiro/freee-work/freee-app-template-firebase/functions/src/freee_sdk/instance.ts
[1] ./src/freee_sdk/instance.ts
[1] [tsl] ERROR in /Users/matsuzawa-shinichiro/freee-work/freee-app-template-firebase/functions/src/freee_sdk/instance.ts(7,10)
[1]       TS2305: Module '"../../../../../../../Users/matsuzawa-shinichiro/freee-work/firebase-sdk-js/lib"' has no exported member 'FreeeServerSDK'.
[2]
```

パスがすごいことになってるのでそこで解決できずに死んでる？

## 動作確認方法
