### PR TITLE
KeyFile取得の失敗時のkeyFile再作成処理を修正

### DIFF
--- a/src/__tests__/sdk/services/freee-cryptor.ts
+++ b/src/__tests__/sdk/services/freee-cryptor.ts
@@ -15,6 +15,7 @@ const mockGetWhenNotCreated = jest
   .mockRejectedValue(new Error('Must not be called'))
 
 let isCreated = true
+let isExists = false
 
 jest.mock('firebase-admin', () => {
   return {
@@ -23,6 +24,7 @@ jest.mock('firebase-admin', () => {
         file: (path: string) => ({
           download: async () =>
             isCreated ? mockGetWhenCreated() : mockGetWhenNotCreated(),
+          exists: async () => [isExists],
           save: () => (isCreated = true)
         })
       })

--- a/src/__tests__/sdk/services/freee-cryptor.ts
+++ b/src/__tests__/sdk/services/freee-cryptor.ts
@@ -3,29 +3,18 @@ import FreeeCryptor from '../../../sdk/services/freee-cryptor'
 
 const key = Buffer.from('aaa', 'utf8')
 
-const mockGetWhenCreated = jest
-  .fn()
-  .mockReturnValueOnce([key])
-  .mockRejectedValue(new Error('Must not be called'))
-
-const mockGetWhenNotCreated = jest
-  .fn()
-  .mockRejectedValueOnce(new Error('Must not be called'))
-  .mockReturnValueOnce([key])
-  .mockRejectedValue(new Error('Must not be called'))
-
-let isCreated = true
-let isExists = false
+const mockDownload = jest.fn()
+const mockExists = jest.fn()
+const mockSave = jest.fn()
 
 jest.mock('firebase-admin', () => {
   return {
     storage: () => ({
       bucket: (path: string) => ({
         file: (path: string) => ({
-          download: async () =>
-            isCreated ? mockGetWhenCreated() : mockGetWhenNotCreated(),
-          exists: async () => [isExists],
-          save: () => (isCreated = true)
+          download: async () => mockDownload(),
+          exists: async () => mockExists(),
+          save: async () => mockSave()
         })
       })
     })
@@ -38,26 +27,78 @@ const keyFileName = '201907'
 
 describe('FreeeCryptor', () => {
   describe('getKey', () => {
-    describe('when crypto key is already created', () => {
-      const cryptor = new FreeeCryptor(bucket)
-
-      it('return key from storage', async () => {
-        expect(await cryptor['getKey'](keyFileName)).toStrictEqual(key)
-      })
-      it('return key from cache(no exception)', async () => {
-        expect(await cryptor['getKey'](keyFileName)).toStrictEqual(key)
-      })
+    beforeEach(async () => {
+      mockDownload.mockReset()
+      mockDownload
+        .mockRejectedValue(new Error('Must not be called'))
+      mockExists.mockReset()
+      mockExists
+        .mockRejectedValue(new Error('Must not be called'))
+      mockSave.mockReset()
+      mockSave
+        .mockRejectedValue(new Error('Must not be called'))
     })
 
-    describe('when crypto key is not created yet', () => {
+    it('when crypto key is already created', async () => {
+      mockDownload.mockReset()
+      mockDownload
+        .mockReturnValueOnce([key])
+        .mockRejectedValue(new Error('Must not be called'))
+
       const cryptor = new FreeeCryptor(bucket)
-      isCreated = false
-      it('return key from storage after create key', async () => {
-        expect(await cryptor['getKey'](keyFileName)).toStrictEqual(key)
-      })
-      it('return key from cache(no exception)', async () => {
-        expect(await cryptor['getKey'](keyFileName)).toStrictEqual(key)
-      })
+      expect(await cryptor['getKey'](keyFileName)).toStrictEqual(key)
+      // return key from cache(no exception)
+      expect(await cryptor['getKey'](keyFileName)).toStrictEqual(key)
+    })
+
+    it('when crypto key is not created yet', async () => {
+      mockDownload.mockReset()
+      mockDownload
+        .mockRejectedValueOnce(new Error('crypto key does not exist'))
+        .mockReturnValueOnce([key])
+        .mockRejectedValue(new Error('Must not be called'))
+      mockExists.mockReset()
+      mockExists
+        .mockReturnValueOnce([false])
+        .mockRejectedValue(new Error('Must not be called'))
+      mockSave.mockReset()
+      mockSave
+        .mockReturnValueOnce(true)
+        .mockRejectedValue(new Error('Must not be called'))
+
+      const cryptor = new FreeeCryptor(bucket)
+      expect(await cryptor['getKey'](keyFileName)).toStrictEqual(key)
+      // return key from cache(no exception)
+      expect(await cryptor['getKey'](keyFileName)).toStrictEqual(key)
+    })
+
+    it('when crypto key is in error', async () => {
+      mockDownload.mockReset()
+      mockDownload
+        .mockRejectedValueOnce(new Error('Unknown download error'))
+        .mockRejectedValue(new Error('Must not be called'))
+      mockExists.mockReset()
+      mockExists
+        .mockRejectedValueOnce(new Error('Unknown exists error'))
+        .mockRejectedValue(new Error('Must not be called'))
+
+      const cryptor = new FreeeCryptor(bucket)
+      await expect(cryptor['getKey'](keyFileName)).rejects.toThrow('Unknown exists error')
+    })
+
+    it('error getting crypto key only once', async () => {
+      mockDownload.mockReset()
+      mockDownload
+        .mockRejectedValueOnce(new Error('Unknown error'))
+        .mockReturnValueOnce([key])
+        .mockRejectedValue(new Error('Must not be called'))
+      mockExists.mockReset()
+      mockExists
+        .mockReturnValueOnce([true])
+        .mockRejectedValue(new Error('Must not be called'))
+
+      const cryptor = new FreeeCryptor(bucket)
+      expect(await cryptor['getKey'](keyFileName)).toStrictEqual(key)
     })
   })
 })

--- a/src/sdk/services/freee-cryptor.ts
+++ b/src/sdk/services/freee-cryptor.ts
@@ -112,9 +112,8 @@ class FreeeCryptor {
       if (!(await this.exists(keyFileName))) {
         console.info('No key file for:', keyFileName)
         await this.create(keyFileName)
-        return await this.get(keyFileName)
       }
-      throw error
+      return await this.get(keyFileName)
     }
   }
 

--- a/src/sdk/services/freee-cryptor.ts
+++ b/src/sdk/services/freee-cryptor.ts
@@ -109,9 +109,12 @@ class FreeeCryptor {
     try {
       return await this.get(keyFileName)
     } catch (error) {
-      console.info('No key file for:', keyFileName)
-      await this.create(keyFileName)
-      return await this.get(keyFileName)
+      if (!(await this.exists(keyFileName))) {
+        console.info('No key file for:', keyFileName)
+        await this.create(keyFileName)
+        return await this.get(keyFileName)
+      }
+      throw error
     }
   }
 
@@ -138,6 +141,16 @@ class FreeeCryptor {
     this.keyCache[keyFileName] = response[0]
     console.log('Crypto key is retrieved from storage for:', keyFileName)
     return response[0]
+  }
+
+  private async exists(keyFileName: string) {
+    const response = await this.bucket.file(keyFileName).exists()
+    const isExists = response[0]
+    console.log(
+      `Crypto key ${isExists ? 'is' : 'is not'} exists storage for:`,
+      keyFileName
+    )
+    return isExists
   }
 }
 


### PR DESCRIPTION
## 概要
KeyFileの取得失敗時に、ファイルが存在しないエラー以外でも上書きしてしまう問題を修正
getKey エラー時にファイル作成前にファイルの存在チェックを追加

## 動作確認方法
異常時のパターンへのunittestを追加しました