### PR TITLE
axiosのバージョンアップ(0.19.0→0.24.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "freee-firebase-sdk",
-  "version": "1.0.1",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1413,11 +1413,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "requires": {
-        "follow-redirects": "1.5.10"
+        "follow-redirects": "^1.14.4"
       }
     },
     "babel-jest": {
@@ -3322,27 +3322,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -23,15 +23,15 @@
   "types": "lib/index.d.js",
   "dependencies": {
     "@google-cloud/storage": "^4.6.0",
-    "axios": "^0.19.0",
+    "axios": "^0.24.0",
     "body-parser": "^1.18.3",
     "crypto": "^1.0.1",
     "date-fns": "^2.11.0",
     "express": "^4.16.4",
     "firebase-admin": "^8.2.0",
     "firebase-functions": "^3.1.0",
-    "simple-oauth2": "^2.2.1",
-    "form-data": "^3.0.0"
+    "form-data": "^3.0.0",
+    "simple-oauth2": "^2.2.1"
   },
   "devDependencies": {
     "@types/axios": "^0.14.0",


### PR DESCRIPTION
## 概要

パッケージのaxiosをバージョンアップ

## 動作確認方法

- https://github.com/C-FO/freee-for-kintone/issues/859
でマージ元ブランチを直接使って動作確認
