### PR TITLE
Fix lint and fmt

### DIFF
--- a/src/__tests__/sdk/services/config-manager.ts
+++ b/src/__tests__/sdk/services/config-manager.ts
@@ -5,8 +5,8 @@ process.env.FIREBASE_CONFIG = JSON.stringify({
   projectId: PROJECT_ID
 })
 
-let mockGetMode = jest.fn().mockReturnValue(MODE)
-let mockGetRegion = jest.fn().mockReturnValue(REGION_US)
+const mockGetMode = jest.fn().mockReturnValue(MODE)
+const mockGetRegion = jest.fn().mockReturnValue(REGION_US)
 
 jest.mock('firebase-functions', () => {
   return {

--- a/src/__tests__/sdk/services/freee-cryptor.ts
+++ b/src/__tests__/sdk/services/freee-cryptor.ts
@@ -10,8 +10,8 @@ const mockSave = jest.fn()
 jest.mock('firebase-admin', () => {
   return {
     storage: () => ({
-      bucket: (path: string) => ({
-        file: (path: string) => ({
+      bucket: (bucketPath: string) => ({
+        file: (filePath: string) => ({
           download: async () => mockDownload(),
           exists: async () => mockExists(),
           save: async () => mockSave()
@@ -29,14 +29,11 @@ describe('FreeeCryptor', () => {
   describe('getKey', () => {
     beforeEach(async () => {
       mockDownload.mockReset()
-      mockDownload
-        .mockRejectedValue(new Error('Must not be called'))
+      mockDownload.mockRejectedValue(new Error('Must not be called'))
       mockExists.mockReset()
-      mockExists
-        .mockRejectedValue(new Error('Must not be called'))
+      mockExists.mockRejectedValue(new Error('Must not be called'))
       mockSave.mockReset()
-      mockSave
-        .mockRejectedValue(new Error('Must not be called'))
+      mockSave.mockRejectedValue(new Error('Must not be called'))
     })
 
     it('when crypto key is already created', async () => {
@@ -83,7 +80,9 @@ describe('FreeeCryptor', () => {
         .mockRejectedValue(new Error('Must not be called'))
 
       const cryptor = new FreeeCryptor(bucket)
-      await expect(cryptor['getKey'](keyFileName)).rejects.toThrow('Unknown exists error')
+      await expect(cryptor['getKey'](keyFileName)).rejects.toThrow(
+        'Unknown exists error'
+      )
     })
 
     it('error getting crypto key only once', async () => {

--- a/src/sdk/api/freee-api-client.ts
+++ b/src/sdk/api/freee-api-client.ts
@@ -1,7 +1,7 @@
 import { AxiosPromise, AxiosStatic } from 'axios'
 import { ParamJSON } from '../const/types'
 import { TokenManager } from '../services/token-manager'
-import * as FormData from 'form-data';
+import * as FormData from 'form-data'
 
 export class FreeeAPIClient {
   private tokenManager: TokenManager
@@ -38,9 +38,8 @@ export class FreeeAPIClient {
    */
   post<T = any>(url: string, data: ParamJSON, userId: string): AxiosPromise<T> {
     return this.tokenManager.get(userId).then(accessToken => {
-
       let sendData = data
-      let sendHeaders: { [key: string]: any }  = {}
+      let sendHeaders: { [key: string]: any } = {}
       let sendContentType = 'application/json'
       const maxContentLength = 104857600
 

--- a/src/sdk/auth/freee-firebase-auth-client.ts
+++ b/src/sdk/auth/freee-firebase-auth-client.ts
@@ -1,12 +1,12 @@
 import { AxiosStatic } from 'axios'
-import * as admin from 'firebase-admin'
+import * as firebaseAdmin from 'firebase-admin'
 import { Response } from 'firebase-functions'
 import { FreeeToken, SDKConfig } from '../const/types'
 import { ConfigKeys, ConfigManager } from '../services/config-manager'
 import { TokenManager } from '../services/token-manager'
 
 export class FreeeFirebaseAuthClient {
-  private admin: admin.app.App
+  private admin: firebaseAdmin.app.App
   private oauth2: any // Can not use typescript version due to mismatch with freee oauth
   private axios: AxiosStatic
   private tokenManager: TokenManager
@@ -22,7 +22,7 @@ export class FreeeFirebaseAuthClient {
   private apiKey?: string
 
   constructor(
-    admin: admin.app.App,
+    admin: firebaseAdmin.app.App,
     oauth2: any,
     axios: AxiosStatic,
     tokenManager: TokenManager,
@@ -64,13 +64,12 @@ export class FreeeFirebaseAuthClient {
    */
   async callback(code: string, res: Response): Promise<void> {
     try {
-      const result = await this.oauth2.authorizationCode
-        .getToken({
-          client_id: this.clientId,
-          client_secret: this.clientSecret,
-          code: code,
-          redirect_uri: `${this.authHost}${this.getCallbackPath()}`
-        })
+      const result = await this.oauth2.authorizationCode.getToken({
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+        code: code,
+        redirect_uri: `${this.authHost}${this.getCallbackPath()}`
+      })
 
       const freeeToken = {
         accessToken: result.access_token,

--- a/src/sdk/services/config-manager.ts
+++ b/src/sdk/services/config-manager.ts
@@ -1,7 +1,7 @@
 import * as functions from 'firebase-functions'
-import { SUPPORTED_REGIONS } from 'firebase-functions'
 import { SDKBaseConfig } from '../const/types'
 
+const SUPPORTED_REGIONS = functions.SUPPORTED_REGIONS
 const adminConfig = JSON.parse(process.env.FIREBASE_CONFIG!)
 const projectId = adminConfig.projectId
 const region =
@@ -108,7 +108,7 @@ const DEFAULT_CONFIGS: DefaltConfigs = {
 export class ConfigManager {
   static get(configs: SDKBaseConfig | null, key: ConfigKeys) {
     if (configs && this.hasKey(configs, key)) {
-      return configs[key]!
+      return configs[key]
     }
 
     return this.getDefaultValue(key)
@@ -122,7 +122,7 @@ export class ConfigManager {
     const defaultConfigs = ([] as DefaultConfig[])
       .concat(DEFAULT_CONFIGS.freee)
       .concat(DEFAULT_CONFIGS.firebase)
-    const config = defaultConfigs.find(config => config.key === key)!
+    const config = defaultConfigs.find(defaultConfig => defaultConfig.key === key)!
     return this.isProduction() && config.production
       ? config.production
       : config.default

--- a/src/sdk/services/token-manager.ts
+++ b/src/sdk/services/token-manager.ts
@@ -1,16 +1,16 @@
-import * as admin from 'firebase-admin'
+import * as firebaseAdmin from 'firebase-admin'
 import { FreeeToken } from '../const/types'
 import FreeeCryptor, { FreeeTokenWithCryptInfo } from './freee-cryptor'
 
 const MARGIN_OF_EXPIRES_SECONDS = 300
 
 export class TokenManager {
-  private admin: admin.app.App
+  private admin: firebaseAdmin.app.App
   private oauth2: any // Can not use typescript version due to mismatch with freee oauth
   private cryptor: FreeeCryptor | null
   private tokenCache: { [key: string]: FreeeTokenWithCryptInfo }
 
-  constructor(admin: admin.app.App, oauth2: any, cryptor: FreeeCryptor | null) {
+  constructor(admin: firebaseAdmin.app.App, oauth2: any, cryptor: FreeeCryptor | null) {
     this.admin = admin
     this.oauth2 = oauth2
     this.cryptor = cryptor


### PR DESCRIPTION
## 概要

`npm run lint` と `npm run fmt` のエラーを解消しました。

## 動作確認方法

- `npm run lint`, `npm run fmt` でエラーが出ず、差分が生じないこと。
- `npm run test` が成功すること。